### PR TITLE
CSV Names, Turning Off Slack Integration, Deleting Old Reports

### DIFF
--- a/facility_activity_report_cron.sh
+++ b/facility_activity_report_cron.sh
@@ -5,6 +5,7 @@ generateEtl() {
   # $3 - MySQL password
   # $4 - Slack channel to post message
   # $5 - Slack token to use
+  # $6 - Report life in days
   cd $1
 
   now="$(date +'%d_%m_%Y_%H_%M_%S')"
@@ -14,10 +15,11 @@ generateEtl() {
   destinationFile="etl/$file_name"
 
   mkdir -p $report_folder
+  find $report_folder -mtime +$6 -exec rm {} \;
   /usr/bin/mysql -u $2 -p$3 < ./facility_activity_report_dml.sql
   /usr/bin/mysql -u $2 -p$3 -e 'select * from path_zambia_etl.facility_activity_report' | sed  's/\t/,/g' > $sourceFile
-  /usr/bin/aws s3 cp $sourceFile s3://opensrp/reports/$destinationFile --acl public-read
+  /usr/bin/aws s3 sync $report_folder s3://opensrp/reports/etl --acl public-read --delete
   /usr/bin/curl -F username="PATH Zambia ETL" -F text="https://s3.amazonaws.com/opensrp/reports/$destinationFile" -F channel=$4 -F token="$5" https://slack.com/api/chat.postMessage
 }
 
-generateEtl $1 $2 $3 $4 $5
+generateEtl $1 $2 $3 $4 $5 $6

--- a/facility_activity_report_cron.sh
+++ b/facility_activity_report_cron.sh
@@ -3,9 +3,9 @@ generateEtl() {
   local pathToScripts=$1
   local mysqlUser=$2
   local mysqlPassword=$3
-  local slackChannel=$4
-  local slackToken=$5
-  local reportLife=$6
+  local reportLife=$4
+  local slackChannel=$5
+  local slackToken=$6
 
   cd $pathToScripts
 
@@ -20,7 +20,9 @@ generateEtl() {
   /usr/bin/mysql -u $mysqlUser -p$mysqlPassword < ./facility_activity_report_dml.sql
   /usr/bin/mysql -u $mysqlUser -p$mysqlPassword -e 'select * from path_zambia_etl.facility_activity_report' | sed  's/\t/,/g' > $sourceFile
   /usr/bin/aws s3 sync $report_folder s3://opensrp/reports/etl --acl public-read --delete
-  /usr/bin/curl -F username="PATH Zambia ETL" -F text="https://s3.amazonaws.com/opensrp/reports/$destinationFile" -F channel=$slackChannel -F token="$slackToken" https://slack.com/api/chat.postMessage
+  if [ -z ${slackChannel+x} ]; then echo "Not sending URL to Slack"; else
+    /usr/bin/curl -F username="PATH Zambia ETL" -F text="https://s3.amazonaws.com/opensrp/reports/$destinationFile" -F channel=$slackChannel -F token="$slackToken" https://slack.com/api/chat.postMessage;
+  fi
 }
 
 generateEtl $1 $2 $3 $4 $5 $6

--- a/facility_activity_report_cron.sh
+++ b/facility_activity_report_cron.sh
@@ -8,7 +8,7 @@ generateEtl() {
   # $6 - Report life in days
   cd $1
 
-  now="$(date +'%d_%m_%Y_%H_%M_%S')"
+  now="$(date +'%d_%m_%Y')"
   file_name="facility_activity_report_$now".csv
   report_folder="./etl"
   sourceFile="$report_folder/$file_name"

--- a/facility_activity_report_cron.sh
+++ b/facility_activity_report_cron.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
 generateEtl() {
-  # $1 - Path to ETL scripts
-  # $2 - MySQL user
-  # $3 - MySQL password
-  # $4 - Slack channel to post message
-  # $5 - Slack token to use
-  # $6 - Report life in days
-  cd $1
+  local pathToScripts=$1
+  local mysqlUser=$2
+  local mysqlPassword=$3
+  local slackChannel=$4
+  local slackToken=$5
+  local reportLife=$6
+
+  cd $pathToScripts
 
   now="$(date +'%d_%m_%Y')"
   file_name="facility_activity_report_$now".csv
@@ -15,11 +16,11 @@ generateEtl() {
   destinationFile="etl/$file_name"
 
   mkdir -p $report_folder
-  find $report_folder -mtime +$6 -exec rm {} \;
-  /usr/bin/mysql -u $2 -p$3 < ./facility_activity_report_dml.sql
-  /usr/bin/mysql -u $2 -p$3 -e 'select * from path_zambia_etl.facility_activity_report' | sed  's/\t/,/g' > $sourceFile
+  find $report_folder -mtime +$reportLife -exec rm {} \;
+  /usr/bin/mysql -u $mysqlUser -p$mysqlPassword < ./facility_activity_report_dml.sql
+  /usr/bin/mysql -u $mysqlUser -p$mysqlPassword -e 'select * from path_zambia_etl.facility_activity_report' | sed  's/\t/,/g' > $sourceFile
   /usr/bin/aws s3 sync $report_folder s3://opensrp/reports/etl --acl public-read --delete
-  /usr/bin/curl -F username="PATH Zambia ETL" -F text="https://s3.amazonaws.com/opensrp/reports/$destinationFile" -F channel=$4 -F token="$5" https://slack.com/api/chat.postMessage
+  /usr/bin/curl -F username="PATH Zambia ETL" -F text="https://s3.amazonaws.com/opensrp/reports/$destinationFile" -F channel=$slackChannel -F token="$slackToken" https://slack.com/api/chat.postMessage
 }
 
 generateEtl $1 $2 $3 $4 $5 $6


### PR DESCRIPTION
Add functionality to prevent the cronjob script from sending Slack notifications, and giving generated CSV files more generic names.

Fixes #7

Add functionality that allows for deleting old generated reports both locally and on S3.

Fixes #6