### PR TITLE
refresh all public materialized views

### DIFF
--- a/opensrp-etl/refresh_all_materialized_views.sql
+++ b/opensrp-etl/refresh_all_materialized_views.sql
@@ -1,0 +1,23 @@
+--
+-- function to refresh all materialized views in a schema
+--
+
+CREATE OR REPLACE FUNCTION RefreshAllMaterializedViews(schema_arg TEXT DEFAULT 'public')
+RETURNS INT AS $$
+	DECLARE
+		r RECORD;
+	BEGIN
+		RAISE NOTICE 'Refreshing materialized view in schema %', schema_arg;
+		FOR r IN SELECT matviewname FROM pg_matviews WHERE schemaname = schema_arg 
+		LOOP
+			RAISE NOTICE 'Refreshing %.%', schema_arg, r.matviewname;
+			EXECUTE 'REFRESH MATERIALIZED VIEW ' || schema_arg || '.' || r.matviewname; 
+		END LOOP;
+		
+		RETURN 1;
+	END 
+$$ LANGUAGE plpgsql;
+
+DO $$ BEGIN
+    PERFORM RefreshAllMaterializedViews();
+END $$;

--- a/opensrp-etl/refresh_all_materialized_views_cron.sh
+++ b/opensrp-etl/refresh_all_materialized_views_cron.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+#Refresh all public materialized views
+export PGPASSWORD="postgres_user_password"
+psql -h localhost -d opensrp -U postgres -f ./refresh_all_materialized_views.sql
+unset PGPASSWORD


### PR DESCRIPTION
The script refreshes all public Materialized views since they are not refreshed automatically. This script is idea to be executed before all other scripts that depend on any public Materialized views.